### PR TITLE
Fix context close duplication

### DIFF
--- a/app/scraper.py
+++ b/app/scraper.py
@@ -265,7 +265,6 @@ async def scrape_followers(
             video_files.append(await p.video.path())
             
         await context.tracing.stop(path=f"/tmp/trace-{target}.zip")
-        await context.close()
 
         print("🎥  Trace  ->", f"/tmp/trace-{target}.zip")
         for v in video_files:


### PR DESCRIPTION
## Summary
- avoid closing the Playwright context twice

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'playwright')*

------
https://chatgpt.com/codex/tasks/task_b_687f1373d1c08331b378c12d4e8b1f2d