### PR TITLE
Improve job entrypoint logging

### DIFF
--- a/app/job_entrypoint.py
+++ b/app/job_entrypoint.py
@@ -30,10 +30,18 @@ async def main() -> None:
         browser = await pw.chromium.launch(headless=True, args=["--no-sandbox"])
 
         state_gcs_uri = os.environ["STATE_GCS_URI"]
-        target      = os.environ["TARGET"]
-        yes         = int(os.getenv("TARGET_YES", 10))
-        batch_size  = int(os.getenv("BATCH_SIZE", 30))
+        target       = os.environ["TARGET"]
+        yes          = int(os.getenv("TARGET_YES", 10))
+        batch_size   = int(os.getenv("BATCH_SIZE", 30))
+
+        print(f"STATE_GCS_URI={state_gcs_uri}", flush=True)
+        print(f"TARGET={target}", flush=True)
+        print(f"TARGET_YES={yes}", flush=True)
+        print(f"BATCH_SIZE={batch_size}", flush=True)
+
         state_path = Path(_download_state_from_gcs(state_gcs_uri))
+
+        print("Starting scrape_followers", flush=True)
 
         results = await scrape_followers(
             browser     = browser,
@@ -43,7 +51,9 @@ async def main() -> None:
             batch_size  = batch_size,
         )
 
-        print(json.dumps(results, indent=2))
+        print("scrape_followers finished", flush=True)
+
+        print(json.dumps(results, indent=2), flush=True)
 
 if __name__ == "__main__":
     asyncio.run(main())

--- a/app/scraper.py
+++ b/app/scraper.py
@@ -33,7 +33,7 @@ BIO_PAGE_TIMEOUT_MS = 10_000        # 10 seconds
 BASE_SCROLL_WAIT = 1.0  # Base wait time after each scroll
 IDLE_SCROLL_WAIT = 3.0  # Base wait time when no new followers detected
 PROGRESSIVE_WAIT = True # If True, wait time increases with each idle loop
-MAX_IDLE_LOOPS = 3      # Number of idle loops before giving up
+MAX_IDLE_LOOPS = 5      # Number of idle loops before giving up (was 3)
 
 # Timeout for HTTP requests
 HTTPX_LONG_TIMEOUT = httpx.Timeout(connect=30.0, write=30.0, read=10_000.0, pool=None)


### PR DESCRIPTION
## Summary
- print environment variables to aid debugging
- log when `scrape_followers` starts and ends
- flush JSON result output
- allow two more idle scrolls before giving up

## Testing
- `pytest -q` *(fails: pyenv not installed; pytest command not found)*

------
https://chatgpt.com/codex/tasks/task_b_687f15caa22c83319abe88ac3d78055d