### PR TITLE
Handle scroll timeout gracefully

### DIFF
--- a/app/scraper.py
+++ b/app/scraper.py
@@ -241,6 +241,7 @@ async def scrape_followers(
         timeout_seconds = 3600  # Cloud Run timeout is 3600 seconds
 
         async with httpx.AsyncClient(timeout=HTTPX_LONG_TIMEOUT) as client:
+            scroll_timeout = False
             while len(yes_rows) < target_yes:
                 # Check if we're approaching timeout (leave 30 seconds buffer for cleanup)
                 elapsed_time = time.perf_counter() - start_time
@@ -267,7 +268,12 @@ async def scrape_followers(
                 previous_count = new_total
 
                 # 3️⃣  Scroll the last visible link into view
-                await user_links.nth(-1).scroll_into_view_if_needed()
+                try:
+                    await user_links.nth(-1).scroll_into_view_if_needed()
+                except PlayTimeout:
+                    print("⚠️ Scroll timeout encountered – likely end of list.")
+                    scroll_timeout = True
+                    break
                 
                 # Dynamic wait time: longer when idle, shorter when making progress
                 if idle_loops > 0:
@@ -338,9 +344,16 @@ async def scrape_followers(
         for v in video_files:
             print("🎞️  Video ->", v)
 
-        # Check if we got partial results due to timeout
+        # Check if we got partial results due to scrolling or timeout
         elapsed_time = time.perf_counter() - start_time
-        if len(yes_rows) < target_yes and elapsed_time >= (timeout_seconds - 30):
+        if scroll_timeout:
+            print(f"⚠️ Returning partial results: {len(yes_rows)}/{target_yes} (scroll timeout)")
+            await send_notification(
+                f"Partial results: {len(yes_rows)}/{target_yes} followers found for @{target} (scroll timeout)",
+                f"Instagram Scraper - Partial Results",
+            )
+            return yes_rows
+        elif len(yes_rows) < target_yes and elapsed_time >= (timeout_seconds - 30):
             print(f"⚠️ Returning partial results: {len(yes_rows)}/{target_yes} (timeout reached after {elapsed_time:.1f}s)")
             # Send notification about partial results
             await send_notification(


### PR DESCRIPTION
## Summary
- handle timeout when scrolling follower list
- return partial results if scrolling reaches the end before timeout

## Testing
- `python3 -m py_compile app/scraper.py`
- `python3 -m py_compile main.py app/__init__.py app/job_entrypoint.py app/scraper.py`

------
https://chatgpt.com/codex/tasks/task_b_6883b229b0c883318af67ce350a0c2d5